### PR TITLE
[RGT-92] full inventory functionality

### DIFF
--- a/Assets/Resources/Prefabs/Tiles/GrassTile.prefab
+++ b/Assets/Resources/Prefabs/Tiles/GrassTile.prefab
@@ -136,7 +136,7 @@ MonoBehaviour:
   validPath: []
   depthText: {fileID: 0}
   coordiantes: {x: 0, y: 0}
-  editorType: 1
+  editorType: 4
   attachedChest: {fileID: 0}
   baseColor: {r: 1, g: 1, b: 1, a: 1}
   offsetColor: {r: 0.9528302, g: 0.9528302, b: 0.9528302, a: 1}

--- a/Assets/Resources/Prefabs/Tiles/GrassTile.prefab
+++ b/Assets/Resources/Prefabs/Tiles/GrassTile.prefab
@@ -98,7 +98,7 @@ PrefabInstance:
     - target: {fileID: 5084094000523550533, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: -1569986566, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
+      objectReference: {fileID: -665997717, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
     - target: {fileID: 6016111808480623132, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 
@@ -136,7 +136,7 @@ MonoBehaviour:
   validPath: []
   depthText: {fileID: 0}
   coordiantes: {x: 0, y: 0}
-  editorType: 1
+  editorType: 4
   attachedChest: {fileID: 0}
   baseColor: {r: 1, g: 1, b: 1, a: 1}
   offsetColor: {r: 0.9528302, g: 0.9528302, b: 0.9528302, a: 1}

--- a/Assets/Resources/Prefabs/Tiles/GrassTile.prefab
+++ b/Assets/Resources/Prefabs/Tiles/GrassTile.prefab
@@ -98,7 +98,7 @@ PrefabInstance:
     - target: {fileID: 5084094000523550533, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: -1569986566, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
+      objectReference: {fileID: -50607854, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
     - target: {fileID: 6016111808480623132, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 
@@ -136,7 +136,7 @@ MonoBehaviour:
   validPath: []
   depthText: {fileID: 0}
   coordiantes: {x: 0, y: 0}
-  editorType: 4
+  editorType: 1
   attachedChest: {fileID: 0}
   baseColor: {r: 1, g: 1, b: 1, a: 1}
   offsetColor: {r: 0.9528302, g: 0.9528302, b: 0.9528302, a: 1}

--- a/Assets/Resources/Prefabs/Tiles/GrassTile.prefab
+++ b/Assets/Resources/Prefabs/Tiles/GrassTile.prefab
@@ -98,7 +98,7 @@ PrefabInstance:
     - target: {fileID: 5084094000523550533, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: -665997717, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
+      objectReference: {fileID: -50607854, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
     - target: {fileID: 6016111808480623132, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 
@@ -136,7 +136,7 @@ MonoBehaviour:
   validPath: []
   depthText: {fileID: 0}
   coordiantes: {x: 0, y: 0}
-  editorType: 1
+  editorType: 4
   attachedChest: {fileID: 0}
   baseColor: {r: 1, g: 1, b: 1, a: 1}
   offsetColor: {r: 0.9528302, g: 0.9528302, b: 0.9528302, a: 1}

--- a/Assets/Resources/Prefabs/Tiles/GrassTile.prefab
+++ b/Assets/Resources/Prefabs/Tiles/GrassTile.prefab
@@ -98,7 +98,7 @@ PrefabInstance:
     - target: {fileID: 5084094000523550533, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: -50607854, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
+      objectReference: {fileID: -1569986566, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
     - target: {fileID: 6016111808480623132, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 
@@ -136,7 +136,7 @@ MonoBehaviour:
   validPath: []
   depthText: {fileID: 0}
   coordiantes: {x: 0, y: 0}
-  editorType: 4
+  editorType: 1
   attachedChest: {fileID: 0}
   baseColor: {r: 1, g: 1, b: 1, a: 1}
   offsetColor: {r: 0.9528302, g: 0.9528302, b: 0.9528302, a: 1}

--- a/Assets/Resources/Prefabs/Tiles/GrassTile.prefab
+++ b/Assets/Resources/Prefabs/Tiles/GrassTile.prefab
@@ -98,7 +98,7 @@ PrefabInstance:
     - target: {fileID: 5084094000523550533, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: -50607854, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
+      objectReference: {fileID: -665997717, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
     - target: {fileID: 6016111808480623132, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 

--- a/Assets/Resources/Prefabs/Tiles/MountainTile.prefab
+++ b/Assets/Resources/Prefabs/Tiles/MountainTile.prefab
@@ -98,7 +98,7 @@ PrefabInstance:
     - target: {fileID: 5084094000523550533, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: -665997717, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
+      objectReference: {fileID: -1569986566, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
 --- !u!212 &441569558929736268 stripped
@@ -148,5 +148,5 @@ MonoBehaviour:
   validPath: []
   depthText: {fileID: 0}
   coordiantes: {x: 0, y: 0}
-  editorType: 2
+  editorType: 3
   attachedChest: {fileID: 0}

--- a/Assets/Resources/Prefabs/Tiles/MountainTile.prefab
+++ b/Assets/Resources/Prefabs/Tiles/MountainTile.prefab
@@ -98,7 +98,7 @@ PrefabInstance:
     - target: {fileID: 5084094000523550533, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: -1569986566, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
+      objectReference: {fileID: -665997717, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
 --- !u!212 &441569558929736268 stripped
@@ -148,5 +148,5 @@ MonoBehaviour:
   validPath: []
   depthText: {fileID: 0}
   coordiantes: {x: 0, y: 0}
-  editorType: 3
+  editorType: 2
   attachedChest: {fileID: 0}

--- a/Assets/Resources/Prefabs/Tiles/MountainTile.prefab
+++ b/Assets/Resources/Prefabs/Tiles/MountainTile.prefab
@@ -98,7 +98,7 @@ PrefabInstance:
     - target: {fileID: 5084094000523550533, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 469488106, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
+      objectReference: {fileID: -50607854, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
 --- !u!212 &441569558929736268 stripped

--- a/Assets/Resources/Prefabs/Tiles/MountainTile.prefab
+++ b/Assets/Resources/Prefabs/Tiles/MountainTile.prefab
@@ -98,7 +98,7 @@ PrefabInstance:
     - target: {fileID: 5084094000523550533, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: -50607854, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
+      objectReference: {fileID: -1569986566, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
 --- !u!212 &441569558929736268 stripped
@@ -148,5 +148,5 @@ MonoBehaviour:
   validPath: []
   depthText: {fileID: 0}
   coordiantes: {x: 0, y: 0}
-  editorType: 2
+  editorType: 3
   attachedChest: {fileID: 0}

--- a/Assets/Resources/Prefabs/Tiles/MountainTile.prefab
+++ b/Assets/Resources/Prefabs/Tiles/MountainTile.prefab
@@ -98,7 +98,7 @@ PrefabInstance:
     - target: {fileID: 5084094000523550533, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: -1569986566, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
+      objectReference: {fileID: 469488106, guid: a0de6dae05b977e48810b3fcf6cc9f3c, type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d82cb805a1775b74b85e643477ca13af, type: 3}
 --- !u!212 &441569558929736268 stripped
@@ -148,5 +148,5 @@ MonoBehaviour:
   validPath: []
   depthText: {fileID: 0}
   coordiantes: {x: 0, y: 0}
-  editorType: 3
+  editorType: 2
   attachedChest: {fileID: 0}

--- a/Assets/Resources/Prefabs/UI/Menus/UnitStatsMenu.prefab
+++ b/Assets/Resources/Prefabs/UI/Menus/UnitStatsMenu.prefab
@@ -170,7 +170,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1354543333722566129
 RectTransform:
   m_ObjectHideFlags: 0
@@ -242,7 +242,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 7623856536820178509}
-  bgimage: {fileID: 0}
   upButton: {fileID: 0}
   downButton: {fileID: 0}
   leftButton: {fileID: 0}
@@ -527,7 +526,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 0}
-  bgimage: {fileID: 0}
   upButton: {fileID: 0}
   downButton: {fileID: 0}
   leftButton: {fileID: 0}
@@ -586,7 +584,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 7623856536820178509}
-  bgimage: {fileID: 7650444140852135620}
   upButton: {fileID: 6986461707469212690}
   downButton: {fileID: 5375941187879584450}
   leftButton: {fileID: 5348877527596605052}
@@ -645,7 +642,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 7630637652410128141}
-  bgimage: {fileID: 7630637652940797540}
   upButton: {fileID: 5348877527596605052}
   downButton: {fileID: 4252545757411850504}
   leftButton: {fileID: 5375941187879584450}
@@ -702,7 +698,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 0}
-  bgimage: {fileID: 0}
   upButton: {fileID: 4252545757411850504}
   downButton: {fileID: 5348877527596605052}
   leftButton: {fileID: 7326349105230057650}
@@ -835,7 +830,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 0}
-  bgimage: {fileID: 0}
   upButton: {fileID: 5624738200652859159}
   downButton: {fileID: 6606305952228801435}
   leftButton: {fileID: 7099161173134065706}
@@ -970,7 +964,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 7630637653537625973}
-  bgimage: {fileID: 7630637652399193474}
   upButton: {fileID: 6606305952228801435}
   downButton: {fileID: 4503828075748938492}
   leftButton: {fileID: 511684294780707801}
@@ -1027,7 +1020,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 0}
-  bgimage: {fileID: 0}
   upButton: {fileID: 511684294780707801}
   downButton: {fileID: 6986461707469212690}
   leftButton: {fileID: 4252545757411850504}
@@ -1084,7 +1076,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 0}
-  bgimage: {fileID: 0}
   upButton: {fileID: 5375941187879584450}
   downButton: {fileID: 7326349105230057650}
   leftButton: {fileID: 5624738200652859159}
@@ -1143,7 +1134,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 7630637653793033759}
-  bgimage: {fileID: 7630637652291665855}
   upButton: {fileID: 5348877527596605052}
   downButton: {fileID: 5624738200652859159}
   leftButton: {fileID: 6732942987678401034}
@@ -1352,7 +1342,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 0}
-  bgimage: {fileID: 0}
   upButton: {fileID: 4503828075748938492}
   downButton: {fileID: 6606305952228801435}
   leftButton: {fileID: 6986461707469212690}
@@ -4014,7 +4003,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 2992844488527346119}
-  bgimage: {fileID: 0}
   upButton: {fileID: 0}
   downButton: {fileID: 0}
   leftButton: {fileID: 0}
@@ -4148,7 +4136,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 7630637653196975340}
-  bgimage: {fileID: 0}
   upButton: {fileID: 7099161173134065706}
   downButton: {fileID: 6732942987678401034}
   leftButton: {fileID: 6606305952228801435}
@@ -4249,7 +4236,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 7650444140852135620}
-  bgimage: {fileID: 0}
   upButton: {fileID: 0}
   downButton: {fileID: 0}
   leftButton: {fileID: 0}
@@ -4306,7 +4292,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   image: {fileID: 0}
-  bgimage: {fileID: 0}
   upButton: {fileID: 6732942987678401034}
   downButton: {fileID: 7099161173134065706}
   leftButton: {fileID: 4503828075748938492}

--- a/Assets/Resources/Prefabs/UI/Menus/UnitSummaryMenu.prefab
+++ b/Assets/Resources/Prefabs/UI/Menus/UnitSummaryMenu.prefab
@@ -270,6 +270,82 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &724066841551434994
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5424556870681597758}
+  - component: {fileID: 6139388778464213920}
+  - component: {fileID: 1909158911346646524}
+  m_Layer: 0
+  m_Name: Highlight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5424556870681597758
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 724066841551434994}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -15.794227}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4684597090119763948}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -637, y: -0.99347}
+  m_SizeDelta: {x: 184.4664, y: 176.3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6139388778464213920
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 724066841551434994}
+  m_CullTransparentMesh: 1
+--- !u!114 &1909158911346646524
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 724066841551434994}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.90442216, b: 0.50377357, a: 0.5764706}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1765447256054872183
 GameObject:
   m_ObjectHideFlags: 0
@@ -301,7 +377,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4684597090119763948}
-  m_RootOrder: 6
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -976,7 +1052,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4684597090119763948}
-  m_RootOrder: 0
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1128,6 +1204,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 2929227253803905100}
+  - {fileID: 5424556870681597758}
   - {fileID: 4684597089324811568}
   - {fileID: 3708768270743686754}
   - {fileID: 72257397193232595}
@@ -1210,6 +1288,7 @@ MonoBehaviour:
   unitIcon: {fileID: 4684597089324811575}
   healthBarTop: {fileID: 4684597090026802738}
   healthBarBottom: {fileID: 4684597090669429398}
+  unitHighlightImage: {fileID: 1909158911346646524}
   weaponButton: {fileID: 3380130881800387802}
   healthText: {fileID: 1161272444557950114}
   weaponClassText: {fileID: 1024954348751651440}
@@ -1225,6 +1304,7 @@ MonoBehaviour:
   - {fileID: 2058188525781131883}
   - {fileID: 3886965569316451938}
   - {fileID: 9027339421705897206}
+  unit: {fileID: 0}
 --- !u!1 &4684597090669429392
 GameObject:
   m_ObjectHideFlags: 0
@@ -1603,7 +1683,7 @@ Transform:
   - {fileID: 4684597090026802739}
   - {fileID: 7354815314413398561}
   m_Father: {fileID: 4684597090119763948}
-  m_RootOrder: 8
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5741097556119776859
 GameObject:
@@ -2041,7 +2121,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4684597090119763948}
-  m_RootOrder: 5
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2323,7 +2403,7 @@ Transform:
   - {fileID: 3917482570131532981}
   - {fileID: 198556870919663143}
   m_Father: {fileID: 4684597090119763948}
-  m_RootOrder: 9
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8400622197863707670
 GameObject:
@@ -2460,6 +2540,82 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &8815284216720588616
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2929227253803905100}
+  - component: {fileID: 2499699364297591538}
+  - component: {fileID: 8296950459708466115}
+  m_Layer: 0
+  m_Name: UnitIcon (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2929227253803905100
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8815284216720588616}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -15.794227}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4684597090119763948}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -637, y: -0.99347}
+  m_SizeDelta: {x: 184.4664, y: 176.3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2499699364297591538
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8815284216720588616}
+  m_CullTransparentMesh: 1
+--- !u!114 &8296950459708466115
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8815284216720588616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a24d210a2a9fa604b83ec44257c4c102, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1001 &252209869357798643
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2477,7 +2633,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
       propertyPath: m_AnchorMax.x
@@ -2622,7 +2778,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
       propertyPath: m_AnchorMax.x
@@ -2735,7 +2891,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
       propertyPath: m_AnchorMax.x
@@ -2848,7 +3004,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
       propertyPath: m_AnchorMax.x
@@ -3029,7 +3185,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4336678512906122866, guid: a14f75fb7864ce443973d00c336b6f79, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 4336678512906122866, guid: a14f75fb7864ce443973d00c336b6f79, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Resources/Skills/Passive/Combat/HyperFocusPS.asset
+++ b/Assets/Resources/Skills/Passive/Combat/HyperFocusPS.asset
@@ -16,11 +16,15 @@ MonoBehaviour:
   skillName: HyperFocus
   description: If unit's HP is above 75%, unit gets +2 to all stats during combat
     and foe cannot make a follow-up attack.
-  menuIcon: {fileID: 21300000, guid: cb56d6fb559380341bc20e181d200eeb, type: 3}
+  menuIcon: {fileID: 21300000, guid: b566fc1f9fd05814ba0e36b08667b89c, type: 3}
   skillIcons:
   - {fileID: -682129567, guid: e0919b6edeea44e4192b22fff9e76a8a, type: 3}
   - {fileID: -108577501, guid: e0919b6edeea44e4192b22fff9e76a8a, type: 3}
   - {fileID: -824462777, guid: e0919b6edeea44e4192b22fff9e76a8a, type: 3}
+  rarity: 0
+  skillType: 0
+  skillRestrictions: 0
+  progressionGroup: {fileID: 0}
   unitClass: 0
   weaponClass: 1
   centered: 0

--- a/Assets/Resources/Weapons/Melee/TestSpear.asset
+++ b/Assets/Resources/Weapons/Melee/TestSpear.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: TestSpear
   m_EditorClassIdentifier: 
   sprite: {fileID: 21300000, guid: 0ec20b6afce746a48a2a9c2dcb9b4a66, type: 3}
-  weaponName: Poleaxe
+  weaponName: Test Poleaxe
   weaponDescription: 
   damage: 0
   weaponClass: 1

--- a/Assets/Resources/Weapons/Ranged/TestStaff.asset
+++ b/Assets/Resources/Weapons/Ranged/TestStaff.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: TestStaff
   m_EditorClassIdentifier: Assembly-CSharp::RangedWeapon
   sprite: {fileID: 21300000, guid: 125c4d3925c62854fa106d4bd734592e, type: 3}
-  weaponName: Test Bow
+  weaponName: Test Tome
   weaponDescription: 
   damage: 5
   weaponClass: 4

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -4870,6 +4870,11 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 72da6607b66d99e498903293fe49d165, type: 2}
   - {fileID: 11400000, guid: 104f64efd9f98654d9beeda10c7d7bb2, type: 2}
   - {fileID: 11400000, guid: 1ad4f5f2ed739cd42a48b09d6ed81f3a, type: 2}
+  - {fileID: 11400000, guid: 9691b7e7173e0de4b84a95993c6ff933, type: 2}
+  - {fileID: 11400000, guid: 4ff9351776674c740b0728d5a29b7ec6, type: 2}
+  - {fileID: 11400000, guid: 74db81d610ced2c42a84c7fba0794893, type: 2}
+  - {fileID: 11400000, guid: a2b6312a16ddd7c47b59049e3b062d68, type: 2}
+  - {fileID: 11400000, guid: 8d085454e388a4542a9d064cb0d148f4, type: 2}
 --- !u!4 &1163073685
 Transform:
   m_ObjectHideFlags: 0
@@ -7373,7 +7378,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1909758492
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -7380,7 +7380,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1909758492
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -688,6 +688,141 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e167a91ba94af0344afd04a6193f1f43, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &53209107
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 53209108}
+  - component: {fileID: 53209110}
+  - component: {fileID: 53209109}
+  m_Layer: 0
+  m_Name: WeaponClassText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &53209108
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 53209107}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1218471199}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1657.0768, y: 509}
+  m_SizeDelta: {x: 479.1361, y: 63.6579}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &53209109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 53209107}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Weapon Class: '
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 56.95
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: -3.823944, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &53209110
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 53209107}
+  m_CullTransparentMesh: 1
 --- !u!1 &73842556
 GameObject:
   m_ObjectHideFlags: 0
@@ -1304,7 +1439,7 @@ Transform:
   - {fileID: 146375917}
   - {fileID: 1713935196}
   m_Father: {fileID: 1909758492}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &198384666
 GameObject:
@@ -1583,6 +1718,82 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 205125643}
+  m_CullTransparentMesh: 1
+--- !u!1 &209386428
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 209386429}
+  - component: {fileID: 209386431}
+  - component: {fileID: 209386430}
+  m_Layer: 5
+  m_Name: BG (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &209386429
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 209386428}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1218471199}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1657.3232, y: 140.44698}
+  m_SizeDelta: {x: 494.2361, y: 1025.7793}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &209386430
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 209386428}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.28266287, g: 0.28807405, b: 0.3773585, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &209386431
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 209386428}
   m_CullTransparentMesh: 1
 --- !u!4 &229462261 stripped
 Transform:
@@ -3215,7 +3426,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1909758492}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3537,6 +3748,82 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 695038438}
   m_CullTransparentMesh: 1
+--- !u!1 &735552100
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 735552101}
+  - component: {fileID: 735552103}
+  - component: {fileID: 735552102}
+  m_Layer: 5
+  m_Name: BG (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &735552101
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 735552100}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 0.297966, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1218471199}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1659, y: 462.724}
+  m_SizeDelta: {x: 494.2361, y: 567.2139}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &735552102
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 735552100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3545746, g: 0.4757319, b: 0.5660378, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &735552103
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 735552100}
+  m_CullTransparentMesh: 1
 --- !u!1001 &741898494
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3839,6 +4126,82 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 99ce855a6cf33504cb61f7a4b03c454d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &795697704
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 795697705}
+  - component: {fileID: 795697707}
+  - component: {fileID: 795697706}
+  m_Layer: 5
+  m_Name: BG (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &795697705
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 795697704}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 0.14992, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1218471199}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1659, y: 602}
+  m_SizeDelta: {x: 494.2361, y: 760.0142}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &795697706
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 795697704}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.254717, g: 0.254717, b: 0.254717, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &795697707
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 795697704}
+  m_CullTransparentMesh: 1
 --- !u!1 &816562099
 GameObject:
   m_ObjectHideFlags: 0
@@ -4908,6 +5271,61 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b7697ab7522b90144a9a9c439c21bf85, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1218471198
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1218471199}
+  - component: {fileID: 1218471200}
+  m_Layer: 0
+  m_Name: DescriptionBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1218471199
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1218471198}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 209386429}
+  - {fileID: 795697705}
+  - {fileID: 735552101}
+  - {fileID: 1731814886}
+  - {fileID: 1483349327}
+  - {fileID: 53209108}
+  - {fileID: 2095369786}
+  m_Father: {fileID: 1909758492}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1218471200
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1218471198}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54124b001ef141348bfe21f8056c815f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nameText: {fileID: 1731814887}
+  descriptionText: {fileID: 1483349328}
+  weaponClassText: {fileID: 53209109}
+  unitClassText: {fileID: 2095369787}
 --- !u!1001 &1306617625
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5498,6 +5916,141 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 99ce855a6cf33504cb61f7a4b03c454d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1483349326
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1483349327}
+  - component: {fileID: 1483349329}
+  - component: {fileID: 1483349328}
+  m_Layer: 0
+  m_Name: DescriptionText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1483349327
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1483349326}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1218471199}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1657.0918, y: 9.4665}
+  m_SizeDelta: {x: 472.5727, y: 729.6599}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1483349328
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1483349326}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Description
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 54
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 20
+  m_fontSizeMax: 45
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 11.471863, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1483349329
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1483349326}
+  m_CullTransparentMesh: 1
 --- !u!4 &1567284994 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8494311217907253899, guid: 400c3d7ad7ff8d84b8a2b02e17e30825, type: 3}
@@ -6755,6 +7308,141 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1731806146}
   m_CullTransparentMesh: 1
+--- !u!1 &1731814885
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1731814886}
+  - component: {fileID: 1731814888}
+  - component: {fileID: 1731814887}
+  m_Layer: 0
+  m_Name: NameText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1731814886
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1731814885}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1218471199}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1657.0768, y: 602.2872}
+  m_SizeDelta: {x: 479.1361, y: 63.6579}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1731814887
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1731814885}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Name
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 56.95
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: -3.823944, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1731814888
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1731814885}
+  m_CullTransparentMesh: 1
 --- !u!1001 &1757134351
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6937,7 +7625,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
       propertyPath: m_AnchorMax.x
@@ -7394,6 +8082,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1646086786}
+  - {fileID: 1218471199}
   - {fileID: 1803597891}
   - {fileID: 1946006750}
   - {fileID: 176929153}
@@ -7458,6 +8147,7 @@ MonoBehaviour:
   itemsScreen: {fileID: 176929152}
   itemScreenSpeed: 10
   hoveredItemButton: {fileID: 1803597892}
+  descriptionMenu: {fileID: 1218471200}
 --- !u!1 &1931128484
 GameObject:
   m_ObjectHideFlags: 0
@@ -7624,7 +8314,7 @@ Transform:
   - {fileID: 478274066}
   - {fileID: 114081868}
   m_Father: {fileID: 1909758492}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1948697011
 PrefabInstance:
@@ -8075,6 +8765,141 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2095369785
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2095369786}
+  - component: {fileID: 2095369788}
+  - component: {fileID: 2095369787}
+  m_Layer: 0
+  m_Name: UnitClassText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2095369786
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2095369785}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1218471199}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1657.0768, y: 426}
+  m_SizeDelta: {x: 479.1361, y: 63.6579}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2095369787
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2095369785}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Unit Class:'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 56.95
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: -3.823944, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &2095369788
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2095369785}
+  m_CullTransparentMesh: 1
 --- !u!1 &2104837693
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -4873,8 +4873,10 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 9691b7e7173e0de4b84a95993c6ff933, type: 2}
   - {fileID: 11400000, guid: 4ff9351776674c740b0728d5a29b7ec6, type: 2}
   - {fileID: 11400000, guid: 74db81d610ced2c42a84c7fba0794893, type: 2}
-  - {fileID: 11400000, guid: a2b6312a16ddd7c47b59049e3b062d68, type: 2}
   - {fileID: 11400000, guid: 8d085454e388a4542a9d064cb0d148f4, type: 2}
+  - {fileID: 11400000, guid: d8a19c2c535920f43aa005b761320edd, type: 2}
+  - {fileID: 11400000, guid: 84101b74117eeed4289321c965b66b94, type: 2}
+  - {fileID: 11400000, guid: 0f6dc50443cc8ff4ba244ab65905456c, type: 2}
 --- !u!4 &1163073685
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1304,7 +1304,7 @@ Transform:
   - {fileID: 146375917}
   - {fileID: 1713935196}
   m_Father: {fileID: 1909758492}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &198384666
 GameObject:
@@ -3215,7 +3215,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1909758492}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -6913,6 +6913,119 @@ MonoBehaviour:
   currentSkill: {fileID: 0}
   activeSkillColor: {r: 0.7264151, g: 0.41290575, b: 0.07812384, a: 1}
   passiveSkillColor: {r: 0.539231, g: 0.71221787, b: 0.9622642, a: 1}
+--- !u!1001 &1803597890
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1909758492}
+    m_Modifications:
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -15.794227
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -1735
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 924
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6087223836051021941, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+      propertyPath: m_Name
+      value: HoveredItemButton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+--- !u!224 &1803597891 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3162040591023099945, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+  m_PrefabInstance: {fileID: 1803597890}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1803597892 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3922988345015968401, guid: e78cbff615e29b74db9382d8beebfaf9, type: 3}
+  m_PrefabInstance: {fileID: 1803597890}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 99ce855a6cf33504cb61f7a4b03c454d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1818340074
 GameObject:
   m_ObjectHideFlags: 0
@@ -7260,7 +7373,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &1909758492
 Transform:
   m_ObjectHideFlags: 0
@@ -7274,6 +7387,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1646086786}
+  - {fileID: 1803597891}
   - {fileID: 1946006750}
   - {fileID: 176929153}
   - {fileID: 647794771}
@@ -7336,6 +7450,7 @@ MonoBehaviour:
   currentInventoryScreen: 0
   itemsScreen: {fileID: 176929152}
   itemScreenSpeed: 10
+  hoveredItemButton: {fileID: 1803597892}
 --- !u!1 &1931128484
 GameObject:
   m_ObjectHideFlags: 0
@@ -7502,7 +7617,7 @@ Transform:
   - {fileID: 478274066}
   - {fileID: 114081868}
   m_Father: {fileID: 1909758492}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1948697011
 PrefabInstance:

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1888,8 +1888,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 239, y: 821}
-  m_SizeDelta: {x: 548.4126, y: 81.2137}
+  m_AnchoredPosition: {x: 401.2334, y: 821}
+  m_SizeDelta: {x: 1221.9448, y: 81.2137}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &369560819
 MonoBehaviour:
@@ -1974,7 +1974,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: -18.411255, y: 0, z: -297.41113, w: 0}
+  m_margin: {x: -15.684204, y: 0, z: -0.43115234, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -7380,7 +7380,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &1909758492
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Managers/InputManager.cs
+++ b/Assets/Scripts/Managers/InputManager.cs
@@ -301,6 +301,9 @@ public class InputManager : MonoBehaviour
     }
     private void OnInventoryMenuPerformed(InputAction.CallbackContext context)
     {
+        if (MenuManager.instance.menuState == MenuState.Battle){
+            return;
+        }
         MenuManager.instance.ToggleInventoryMenu();
     }
 

--- a/Assets/Scripts/Managers/InputManager.cs
+++ b/Assets/Scripts/Managers/InputManager.cs
@@ -194,8 +194,9 @@ public class InputManager : MonoBehaviour
             return;
         }
         if (MenuManager.instance.InMenu()){
-            if (MenuManager.instance.menuState == MenuState.Inventory){
-                //TODO: MAKE INVENTORY MENU CLOSE SUBMENUS
+            if (MenuManager.instance.menuState == MenuState.Inventory && MenuManager.instance.inventoryMenu.hoveredItem != null){
+                MenuManager.instance.inventoryMenu.UnhoverItem();
+                return;
             }
             MenuManager.instance.CloseMenus();
             return;

--- a/Assets/Scripts/Managers/InputManager.cs
+++ b/Assets/Scripts/Managers/InputManager.cs
@@ -256,6 +256,7 @@ public class InputManager : MonoBehaviour
             TurnManager.instance.GoToPreviousUnit();
         }
         if (mm.menuState == MenuState.Inventory){
+            mm.inventoryMenu.UnhoverItem();
             mm.InventoryShowUntis();
         }    
     }
@@ -270,6 +271,7 @@ public class InputManager : MonoBehaviour
             TurnManager.instance.GoToNextUnit();
         }
         if (mm.menuState == MenuState.Inventory){
+            mm.inventoryMenu.UnhoverItem();
             mm.InventoryShowItems();
         }
     }

--- a/Assets/Scripts/Managers/InputManager.cs
+++ b/Assets/Scripts/Managers/InputManager.cs
@@ -194,9 +194,15 @@ public class InputManager : MonoBehaviour
             return;
         }
         if (MenuManager.instance.InMenu()){
-            if (MenuManager.instance.menuState == MenuState.Inventory && MenuManager.instance.inventoryMenu.hoveredItem != null){
-                MenuManager.instance.inventoryMenu.UnhoverItem();
-                return;
+            if (MenuManager.instance.menuState == MenuState.Inventory ) {
+                if (MenuManager.instance.inventoryMenu.hoveredItem != null){
+                    MenuManager.instance.inventoryMenu.UnhoverItem();
+                    return;
+                }
+                if (MenuManager.instance.inventoryMenu.currentInventoryScreen == InventoryScreen.Items){
+                    MenuManager.instance.inventoryMenu.ChangeInventoryScreen();
+                    return;
+                }
             }
             MenuManager.instance.CloseMenus();
             return;

--- a/Assets/Scripts/Managers/InputManager.cs
+++ b/Assets/Scripts/Managers/InputManager.cs
@@ -194,6 +194,9 @@ public class InputManager : MonoBehaviour
             return;
         }
         if (MenuManager.instance.InMenu()){
+            if (MenuManager.instance.menuState == MenuState.Inventory){
+                //TODO: MAKE INVENTORY MENU CLOSE SUBMENUS
+            }
             MenuManager.instance.CloseMenus();
             return;
         }
@@ -283,6 +286,13 @@ public class InputManager : MonoBehaviour
 
     private void OnUnitMenuPerformed(InputAction.CallbackContext context)
     {
+        if (MenuManager.instance.menuState == MenuState.Inventory){
+            MenuManager.instance.inventoryMenu.UnequipItem();
+            return;
+        }
+        if (MenuManager.instance.InMenu()){
+            return;
+        }
         MenuManager.instance.ToggleUnitActionMenu();
     }
     private void OnUnitMenuCanceled(InputAction.CallbackContext context)

--- a/Assets/Scripts/Managers/InventoryManager.cs
+++ b/Assets/Scripts/Managers/InventoryManager.cs
@@ -1,7 +1,8 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-
+using System.Linq;
 public class InventoryManager : MonoBehaviour
 {
     public static InventoryManager instance;
@@ -32,5 +33,22 @@ public class InventoryManager : MonoBehaviour
     }
     public int ItemCount(){
         return items.Count;
+    }
+    public void AddItem(BaseItem item){
+        items.Add(item);
+    }
+    public void RemoveItem(BaseItem item){
+        items.Remove(item);
+    }
+
+
+    public void SortInventory(BaseUnit unit, ItemType type)
+    {
+        //MOVE BUTTONS THAT ARE ON TO THE FRONT
+        if (type == ItemType.Skill){
+            items = items.OrderByDescending(i => unit.CanUseSkill(i)).ToList();
+        }else{
+            items = items.OrderByDescending(i => unit.CanUseWeapon(i)).ToList();
+        }
     }
 }

--- a/Assets/Scripts/Managers/MenuManager.cs
+++ b/Assets/Scripts/Managers/MenuManager.cs
@@ -130,7 +130,6 @@ public class MenuManager : MonoBehaviour
             CloseMenus();
             return;
         }
-        Debug.Log(UnitManager.instance.selectedUnit);
         if (UnitManager.instance.selectedUnit == null){
             var temp = GridManager.instance.hoveredTile.occupiedUnit;
 //            Debug.Log(temp);

--- a/Assets/Scripts/Menus/BaseMenu.cs
+++ b/Assets/Scripts/Menus/BaseMenu.cs
@@ -63,6 +63,9 @@ public class BaseMenu : MonoBehaviour
         SetHighlight();
     }
     protected MenuButton GetCurrentButton(){
+        if (buttonIndex >= buttons.Count || buttonIndex < 0){
+            return null;
+        }
         return buttons[buttonIndex];
     }
     public virtual void Reset(){

--- a/Assets/Scripts/Menus/BaseMenu.cs
+++ b/Assets/Scripts/Menus/BaseMenu.cs
@@ -97,7 +97,6 @@ public class BaseMenu : MonoBehaviour
     public void SetFirstIndex(){
         int index = 0;
         foreach (MenuButton menuButton in buttons){
-            Debug.Log(index);
             if (menuButton.IsOn()){
                 buttonIndex = index;
                 return;

--- a/Assets/Scripts/Menus/BaseMenu.cs
+++ b/Assets/Scripts/Menus/BaseMenu.cs
@@ -94,6 +94,17 @@ public class BaseMenu : MonoBehaviour
     public virtual void Select(){
 
     }
+    public void SetFirstIndex(){
+        int index = 0;
+        foreach (MenuButton menuButton in buttons){
+            Debug.Log(index);
+            if (menuButton.IsOn()){
+                buttonIndex = index;
+                return;
+            }
+            index += 1;
+        }
+    }
 }
 
 public enum MenuDirection {

--- a/Assets/Scripts/Menus/DescriptionMenu.cs
+++ b/Assets/Scripts/Menus/DescriptionMenu.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using TMPro;
+using UnityEngine.UI;
+using Unity.VisualScripting;
+
+public class DescriptionMenu : MonoBehaviour
+{
+    public TMP_Text nameText, descriptionText, weaponClassText, unitClassText;
+}

--- a/Assets/Scripts/Menus/DescriptionMenu.cs.meta
+++ b/Assets/Scripts/Menus/DescriptionMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54124b001ef141348bfe21f8056c815f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Menus/InventoryMenu.cs
+++ b/Assets/Scripts/Menus/InventoryMenu.cs
@@ -218,8 +218,7 @@ public class InventoryMenu : BaseMenu
                 ub.SetOn(false);
                 continue;
             }
-            BaseWeapon weapon = item as BaseWeapon;
-            if (weapon != null && weapon.weaponClass == hoveredWeapon.weaponClass){
+            if (ub.unit.weaponClass == hoveredWeapon.weaponClass){
                 ub.SetOn(true);
             }else{
                 ub.SetOn(false);
@@ -318,6 +317,30 @@ public class InventoryMenu : BaseMenu
     {
         hoveredItem = null;
         hoveredItemButton.Reset();
+        ResetButtons();
+    }
+
+    internal void UnequipItem()
+    {
+        if (currentInventoryScreen == InventoryScreen.Items){
+            return;
+        }
+        var menuButton = GetCurrentButton();
+        if (menuButton is not ItemButton){
+            return;
+        }
+        ItemButton ib = menuButton as ItemButton;
+
+        var item = ib.GetItem();
+        if (item == null){
+            return;
+        }
+        InventoryManager.instance.AddItem(item);
+        if (item is BaseWeapon){
+            ib.unit.weapon = null;
+        } else {
+            ib.unit.skills[ib.index] = null;
+        }
         ResetButtons();
     }
 }

--- a/Assets/Scripts/Menus/InventoryMenu.cs
+++ b/Assets/Scripts/Menus/InventoryMenu.cs
@@ -26,7 +26,26 @@ public class InventoryMenu : BaseMenu
         }
         base.Move(direction);
         SetNameText();
+        if (currentInventoryScreen == InventoryScreen.Items){
+            HighlightUnits();
+        }
     }
+
+    private void HighlightUnits()
+    {
+        var button = GetCurrentButton();
+        if (button is not ItemButton){
+            return;
+        }
+        BaseItem i = (button as ItemButton).GetItem();
+        foreach (UnitSummaryMenu usm in unitSummaries){
+            usm.unitHighlightImage.gameObject.SetActive(false);
+            if (usm.unit.CanUseSkill(i) || usm.unit.CanUseWeapon(i)){
+                usm.unitHighlightImage.gameObject.SetActive(true);
+            }
+        }
+    }
+
     public void Update(){
         if (itemScreenNextPos != itemsScreen.transform.localPosition){
             itemsScreen.transform.localPosition = Vector2.Lerp(itemsScreen.transform.localPosition, itemScreenNextPos, itemScreenSpeed*Time.deltaTime);

--- a/Assets/Scripts/Menus/InventoryMenu.cs
+++ b/Assets/Scripts/Menus/InventoryMenu.cs
@@ -213,16 +213,27 @@ public class InventoryMenu : BaseMenu
             if (mb is not ItemButton){
                 return;
             }
-            ItemButton ub = mb as ItemButton;
-            BaseItem item = ub.GetItem();
+            ItemButton ib = mb as ItemButton;
+            BaseItem item = ib.GetItem();
             if (item is BaseSkill){
-                ub.SetOn(false);
+                ib.SetOn(false);
                 continue;
             }
-            if (ub.unit.weaponClass == hoveredWeapon.weaponClass){
-                ub.SetOn(true);
-            }else{
-                ub.SetOn(false);
+            BaseWeapon weapon = item as BaseWeapon;
+            if (ib.unit == null){
+                // Debug.Log(ib.unit);
+                // Debug.Log(hoveredWeapon);
+                if (weapon != null && weapon.weaponClass == hoveredWeapon.weaponClass){
+                    ib.SetOn(true);
+                }else{
+                    ib.SetOn(false);
+                }
+            }else {
+                if (ib.unit.weaponClass == hoveredWeapon.weaponClass){
+                    ib.SetOn(true);
+                }else{
+                    ib.SetOn(false);
+                }
             }
         }
     }

--- a/Assets/Scripts/Menus/InventoryMenu.cs
+++ b/Assets/Scripts/Menus/InventoryMenu.cs
@@ -70,6 +70,7 @@ public class InventoryMenu : BaseMenu
 
     private void ResetButtons()
     {
+        hoveredItemButton.gameObject.SetActive(false);
         hoveredItem = null;
         hoveredItemButton.Reset();
         unitButtons = new();
@@ -134,12 +135,13 @@ public class InventoryMenu : BaseMenu
             }
         }
         //IF NOT UNITS CAN USE IT, DO NOT SWAP MENUS
-        if (noUnits){
+        if (noUnits && currentInventoryScreen == InventoryScreen.Items){
             buttonNameText.text = "No units found that can use that item!";
             hoveredItem = null;
             //Debug.Log("no units found that can use that item!");
             return;
         }
+        hoveredItemButton.gameObject.SetActive(true);
         ChangeInventoryScreen();
         if (currentInventoryScreen == InventoryScreen.Units){
             hoveredItemButton.unit = ib.unit;
@@ -155,7 +157,6 @@ public class InventoryMenu : BaseMenu
                 hoveredItemButton.SetItem(hoveredItem, ib.index);
                 HighlightItemSkills(hoveredItem as BaseSkill);
             }
-            hoveredItemButton.SetItem(hoveredItem);
         }else{
             //WHEN SWAPPING TO UNITS
             hoveredItemButton.SetItem(hoveredItem);

--- a/Assets/Scripts/Menus/InventoryMenu.cs
+++ b/Assets/Scripts/Menus/InventoryMenu.cs
@@ -70,9 +70,10 @@ public class InventoryMenu : BaseMenu
         }
     }
 
-    private void ResetItemButtons()
+    private void ResetItemButtons(bool start = true)
     {
         inventoryButtons.ForEach(ib => ib.SetOn(false));
+        inventoryButtons.ForEach(ib => (ib as ItemButton).Reset());
         for (int i = 0; i < InventoryManager.instance.ItemCount(); i++)
         {
             var b = inventoryButtons[i];
@@ -104,22 +105,23 @@ public class InventoryMenu : BaseMenu
 
         //TODO: ONLY HIGHLIGHT OBJECTS THAT CAN BE SWAPPED
         ChangeInventoryScreen();
-         hoveredItem = ib.GetItem();
+        hoveredItem = ib.GetItem();
         if (currentInventoryScreen == InventoryScreen.Units){
             hoveredItemButton.unit = ib.unit;
             ItemType iType;
             //WHEN SWAPPING TO ITEMS
             if (hoveredItem is BaseWeapon){
+                InventoryManager.instance.SortInventory(ib.unit, ItemType.Weapon);
+                ResetItemButtons();
                 hoveredItemButton.SetItem(hoveredItem, 3);
                 HighlightWeapons(hoveredItem as BaseWeapon);
-                iType = ItemType.Weapon;
             }else{
+                InventoryManager.instance.SortInventory(ib.unit, ItemType.Skill);
+                ResetItemButtons();
                 hoveredItemButton.SetItem(hoveredItem, ib.index);
                 HighlightItemSkills(hoveredItem as BaseSkill);
-                iType = ItemType.Skill;
             }
-            InventoryManager.instance.SortInventory(ib.unit, iType);
-            ResetItemButtons();
+
             hoveredItemButton.SetItem(hoveredItem);
         }else{
             //WHEN SWAPPING TO UNITS
@@ -184,7 +186,7 @@ public class InventoryMenu : BaseMenu
                 continue;
             }
             BaseWeapon weapon = item as BaseWeapon;
-            if (weapon.weaponClass == hoveredWeapon.weaponClass){
+            if (weapon != null && weapon.weaponClass == hoveredWeapon.weaponClass){
                 ub.SetOn(true);
             }else{
                 ub.SetOn(false);
@@ -277,7 +279,7 @@ public class InventoryMenu : BaseMenu
         }
         Move(Vector2.zero);
 
-        Debug.Log(buttonIndex);        
+//        Debug.Log(buttonIndex);        
         yield return null;
     }
 

--- a/Assets/Scripts/Menus/InventoryMenu.cs
+++ b/Assets/Scripts/Menus/InventoryMenu.cs
@@ -19,6 +19,7 @@ public class InventoryMenu : BaseMenu
     private bool menuMoving;
     private BaseItem hoveredItem;
     public ItemButton hoveredItemButton;
+    public DescriptionMenu descriptionMenu;
     public override void Move(Vector2 direction)
     {
         if (menuMoving){
@@ -283,6 +284,29 @@ public class InventoryMenu : BaseMenu
     }
     private void SetNameText(){
         buttonNameText.text = InventoryManager.instance.GetItemName(buttonIndex);
+        MenuButton button = GetCurrentButton();
+        if (button == null || button is not ItemButton){
+            return;
+        }
+        ItemButton ib = button as ItemButton;
+        if (ib.item == null){
+            descriptionMenu.descriptionText.text = "";
+            descriptionMenu.nameText.text = "";
+            descriptionMenu.gameObject.SetActive(false);
+            return;
+        }
+        if (ib.item is BaseWeapon){
+            descriptionMenu.descriptionText.text = "";
+            descriptionMenu.nameText.text = "";
+            descriptionMenu.gameObject.SetActive(false);
+        }else{
+            BaseSkill skill = ib.item as BaseSkill;
+            descriptionMenu.gameObject.SetActive(true);
+            descriptionMenu.descriptionText.text = skill.description;
+            descriptionMenu.weaponClassText.text = "Weapon: " + skill.weaponClass;
+            descriptionMenu.unitClassText.text = "Unit: " + skill.unitClass;
+            descriptionMenu.nameText.text = skill.skillName;
+        }
     }
     
     internal void ShowUnits()
@@ -310,6 +334,7 @@ public class InventoryMenu : BaseMenu
     }
     IEnumerator WhileMoving(){
         menuMoving = true;
+        descriptionMenu.gameObject.SetActive(false);
         highlighImage.gameObject.SetActive(false);
         yield return new WaitForSeconds(0.5f);
         highlighImage.gameObject.SetActive(true);

--- a/Assets/Scripts/Menus/InventoryMenu.cs
+++ b/Assets/Scripts/Menus/InventoryMenu.cs
@@ -17,6 +17,8 @@ public class InventoryMenu : BaseMenu
     private Vector3 itemScreenNextPos;
     public float itemScreenSpeed;
     private bool menuMoving;
+    private BaseItem hoveredItem;
+    public ItemButton hoveredItemButton;
     public override void Move(Vector2 direction)
     {
         if (menuMoving){
@@ -35,8 +37,10 @@ public class InventoryMenu : BaseMenu
     public override void Reset()
     {
         SetNameText();
+        hoveredItemButton.Reset();
         this.xCount = 4;
         this.yCount = 5;
+        hoveredItem = null;
         unitButtons = new();
         itemsScreen.transform.localPosition = new(860, 180);
         itemScreenNextPos = itemsScreen.transform.localPosition;
@@ -63,15 +67,27 @@ public class InventoryMenu : BaseMenu
     }
     public override void Select()
     {
-        //Debug.Log(buttonNameText.text);
+        MenuButton menuButton = buttons[buttonIndex];
+        if (menuButton is not ItemButton){
+            return;
+        }
+        ItemButton ib = menuButton as ItemButton;
+        hoveredItem = ib.GetItem();
+        hoveredItemButton.SetItem(hoveredItem);
+        ChangeInventoryScreen();
     }
-    public void ChangeInventoryScreen(){
 
+    public void ChangeInventoryScreen(){
+        if (currentInventoryScreen == InventoryScreen.Items){
+            ShowUnits();
+        }else{
+            ShowItems();
+        }
     }
     private void SetNameText(){
         buttonNameText.text = InventoryManager.instance.GetItemName(buttonIndex);
     }
-
+    
     internal void ShowUnits()
     {
         if (menuMoving){

--- a/Assets/Scripts/Menus/InventoryMenu.cs
+++ b/Assets/Scripts/Menus/InventoryMenu.cs
@@ -40,6 +40,9 @@ public class InventoryMenu : BaseMenu
         }
         BaseItem i = (button as ItemButton).GetItem();
         foreach (UnitSummaryMenu usm in unitSummaries){
+            if (usm.unit == null){
+                continue;
+            }
             usm.unitHighlightImage.gameObject.SetActive(false);
             if (usm.unit.CanUseSkill(i) || usm.unit.CanUseWeapon(i)){
                 usm.unitHighlightImage.gameObject.SetActive(true);
@@ -58,7 +61,7 @@ public class InventoryMenu : BaseMenu
         SetNameText();
         hoveredItemButton.Reset();
         this.xCount = 4;
-        this.yCount = 5;
+        this.yCount = UnitManager.instance.GetAllHeroes().Count;
 
         itemsScreen.transform.localPosition = new(860, 180);
         itemScreenNextPos = itemsScreen.transform.localPosition;
@@ -78,9 +81,12 @@ public class InventoryMenu : BaseMenu
         //DISPLAY INVENTORY ITEMS CODE
         ResetItemButtons();
         var heroes = UnitManager.instance.GetAllHeroes();
+        unitSummaries.ForEach(summary => summary.unit = null);
+        unitSummaries.ForEach(summary => summary.gameObject.SetActive(false));
         for (int i = 0; i < heroes.Count; i++)
         {
             UnitSummaryMenu summary = unitSummaries[i];
+            summary.gameObject.SetActive(true);
             summary.Init(heroes[i]);
             unitButtons.Add(summary.weaponButton);
             summary.weaponButton.SetOn(true);
@@ -317,7 +323,7 @@ public class InventoryMenu : BaseMenu
         itemScreenNextPos += new Vector3(1700, 0);
         buttons = unitButtons;
         this.xCount = 4;
-        this.yCount = 5;
+        this.yCount = UnitManager.instance.GetAllHeroes().Count;
         StartCoroutine(WhileMoving());
     }
 

--- a/Assets/Scripts/Menus/InventoryMenu.cs
+++ b/Assets/Scripts/Menus/InventoryMenu.cs
@@ -61,6 +61,7 @@ public class InventoryMenu : BaseMenu
 
         itemsScreen.transform.localPosition = new(860, 180);
         itemScreenNextPos = itemsScreen.transform.localPosition;
+        menuMoving = false;
         ResetButtons();
         currentInventoryScreen = InventoryScreen.Units;
         buttons = unitButtons;
@@ -127,7 +128,6 @@ public class InventoryMenu : BaseMenu
         hoveredItem = ib.GetItem();
         if (currentInventoryScreen == InventoryScreen.Units){
             hoveredItemButton.unit = ib.unit;
-            ItemType iType;
             //WHEN SWAPPING TO ITEMS
             if (hoveredItem is BaseWeapon){
                 InventoryManager.instance.SortInventory(ib.unit, ItemType.Weapon);
@@ -296,9 +296,7 @@ public class InventoryMenu : BaseMenu
         }else{
             currentInventoryScreen = InventoryScreen.Units;
         }
-        Move(Vector2.zero);
-
-//        Debug.Log(buttonIndex);        
+        Move(Vector2.zero);     
         yield return null;
     }
 

--- a/Assets/Scripts/Menus/InventoryMenu.cs
+++ b/Assets/Scripts/Menus/InventoryMenu.cs
@@ -17,7 +17,7 @@ public class InventoryMenu : BaseMenu
     private Vector3 itemScreenNextPos;
     public float itemScreenSpeed;
     private bool menuMoving;
-    private BaseItem hoveredItem;
+    public BaseItem hoveredItem;
     public ItemButton hoveredItemButton;
     public DescriptionMenu descriptionMenu;
     public override void Move(Vector2 direction)

--- a/Assets/Scripts/Menus/InventoryMenu.cs
+++ b/Assets/Scripts/Menus/InventoryMenu.cs
@@ -124,8 +124,23 @@ public class InventoryMenu : BaseMenu
         }
 
         //TODO: ONLY HIGHLIGHT OBJECTS THAT CAN BE SWAPPED
-        ChangeInventoryScreen();
         hoveredItem = ib.GetItem();
+        //CHECK IF ANY UNITS CAN USE THIS ITEM
+        bool noUnits = true;
+        foreach (BaseUnit unit in UnitManager.instance.GetAllHeroes()){
+            if (unit.CanUseSkill(hoveredItem) || unit.CanUseWeapon(hoveredItem)){
+                noUnits = false;
+                break;
+            }
+        }
+        //IF NOT UNITS CAN USE IT, DO NOT SWAP MENUS
+        if (noUnits){
+            buttonNameText.text = "No units found that can use that item!";
+            hoveredItem = null;
+            //Debug.Log("no units found that can use that item!");
+            return;
+        }
+        ChangeInventoryScreen();
         if (currentInventoryScreen == InventoryScreen.Units){
             hoveredItemButton.unit = ib.unit;
             //WHEN SWAPPING TO ITEMS
@@ -140,7 +155,6 @@ public class InventoryMenu : BaseMenu
                 hoveredItemButton.SetItem(hoveredItem, ib.index);
                 HighlightItemSkills(hoveredItem as BaseSkill);
             }
-
             hoveredItemButton.SetItem(hoveredItem);
         }else{
             //WHEN SWAPPING TO UNITS

--- a/Assets/Scripts/Menus/ItemButton.cs
+++ b/Assets/Scripts/Menus/ItemButton.cs
@@ -29,6 +29,8 @@ public class ItemButton : MenuButton
     public virtual void SetItem(BaseItem item, int index = -1){
         this.index = index;
         if (item == null){
+            this.image.sprite = null;
+            this.item = null;
             return;
         }
         this.item = item;

--- a/Assets/Scripts/Menus/ItemButton.cs
+++ b/Assets/Scripts/Menus/ItemButton.cs
@@ -10,10 +10,24 @@ public class ItemButton : MenuButton
     public BaseUnit unit;
     public BaseItem item;
     public Image bgImage;
+    public int index;
+    public void Reset(){
+        unit = null;
+        item = null;
+        image.sprite = null;
+        bgImage.color = Color.white;
+    }
     public override void OnPress(){
         //TODO PICKUP ITEM AND MOVE TO OTHER MENU
     }
-    public virtual void SetItem(BaseItem item){
+    public BaseItem GetItem(){
+        return item;
+    }
+    public virtual void SetUnit(BaseUnit unit){
+        this.unit = unit;
+    }
+    public virtual void SetItem(BaseItem item, int index = -1){
+        this.index = index;
         if (item == null){
             return;
         }

--- a/Assets/Scripts/Menus/MenuButton.cs
+++ b/Assets/Scripts/Menus/MenuButton.cs
@@ -29,6 +29,7 @@ public class MenuButton : MonoBehaviour
     public bool IsOn(){
         return isOn;
     }
+
     public void SetOn(bool on = true){
         isOn = on;
         float alpha = on ? 1.0f : 0.25f;

--- a/Assets/Scripts/Menus/MenuButton.cs
+++ b/Assets/Scripts/Menus/MenuButton.cs
@@ -31,7 +31,13 @@ public class MenuButton : MonoBehaviour
     }
     public void SetOn(bool on = true){
         isOn = on;
-        buttonText.alpha = on ? 1.0f : 0.25f;
+        float alpha = on ? 1.0f : 0.25f;
+        if (buttonText != null){
+            buttonText.alpha = alpha;
+        }
+        if (image != null){
+            image.color = new(image.color.r, image.color.g, image.color.b, alpha);
+        }
     }
     public virtual void OnPress(){
         

--- a/Assets/Scripts/Menus/UnitStatsMenu.cs
+++ b/Assets/Scripts/Menus/UnitStatsMenu.cs
@@ -43,7 +43,11 @@ public class UnitStatsMenu : BaseMenu
         unitIcon.sprite = unit.GetSprite();
         unitNameText.text = unit.unitName;
         unitClassText.text = unit.unitClass.ToString();
-        weaponImage.sprite = unit.weapon.sprite;
+        if (unit.weapon != null){
+            weaponImage.sprite = unit.weapon.sprite;
+        }else{
+            weaponImage.sprite = null;
+        }
         weaponText.text = unit.weapon.weaponName;
         weaponClassText.text = unit.weapon.weaponClass.ToString();
         

--- a/Assets/Scripts/Menus/UnitSummaryMenu.cs
+++ b/Assets/Scripts/Menus/UnitSummaryMenu.cs
@@ -13,6 +13,7 @@ public class UnitSummaryMenu : BaseMenu
     public XPMenu xpBar;
     public TMP_Text atkT, defT, aglT, atuT, frsT, lckT;
     public List<ItemButton> itemButtons = new();
+
     public void Init(BaseUnit unit){
         xpBar.SetUnit(unit);
         unitIcon.sprite = unit.GetSprite();
@@ -22,10 +23,14 @@ public class UnitSummaryMenu : BaseMenu
         weaponClassText.text = unit.weaponClass.ToString();
         unitClassText.text = unit.unitClass.ToString();
 
-        weaponButton.SetItem(unit.weapon);
-        itemButtons[0].SetItem(unit.GetSkill(0));
-        itemButtons[1].SetItem(unit.GetSkill(1));
-        itemButtons[2].SetItem(unit.GetSkill(2));
+        weaponButton.SetItem(unit.weapon, 0);
+        weaponButton.SetUnit(unit);
+        itemButtons[0].SetItem(unit.GetSkill(0), 0);
+        itemButtons[0].SetUnit(unit);
+        itemButtons[1].SetItem(unit.GetSkill(1), 1);
+        itemButtons[1].SetUnit(unit);
+        itemButtons[2].SetItem(unit.GetSkill(2), 2);
+        itemButtons[2].SetUnit(unit);
 
         var atk = unit.GetAttack();
         atkT.text = atk.total.ToString();

--- a/Assets/Scripts/Menus/UnitSummaryMenu.cs
+++ b/Assets/Scripts/Menus/UnitSummaryMenu.cs
@@ -7,17 +7,19 @@ using UnityEngine.UI;
 
 public class UnitSummaryMenu : BaseMenu
 {
-    public Image unitIcon, healthBarTop, healthBarBottom;
+    public Image unitIcon, healthBarTop, healthBarBottom, unitHighlightImage;
     public ItemButton weaponButton;
     public TextMeshProUGUI healthText, weaponClassText, unitClassText;
     public XPMenu xpBar;
     public TMP_Text atkT, defT, aglT, atuT, frsT, lckT;
     public List<ItemButton> itemButtons = new();
-
+    public BaseUnit unit;
     public void Init(BaseUnit unit){
+        this.unit = unit;
         xpBar.SetUnit(unit);
         unitIcon.sprite = unit.GetSprite();
-        unitIcon.color = unit.GetColor();
+        //unitIcon.color = unit.GetColor();
+        unitHighlightImage.gameObject.SetActive(false);
         healthBarTop.fillAmount = (float)unit.health / (float)unit.maxHealth;
         healthText.text = unit.health + " / " + unit.maxHealth;
         weaponClassText.text = unit.weaponClass.ToString();

--- a/Assets/Scripts/Units/BaseUnit.cs
+++ b/Assets/Scripts/Units/BaseUnit.cs
@@ -90,31 +90,31 @@ public class BaseUnit : MonoBehaviour
     public virtual void ApplyWeapon(){
 
     }
-    private void InitializeUnitClass()
+    protected virtual void InitializeUnitClass()
     {
-        switch (unitClass){
-            case UnitClass.Infantry:
-                armorType = ArmorType.Medium;
-                break;
-            case UnitClass.Knight:
-                armorType = ArmorType.Heavy;
-                break;
-            case UnitClass.Assassin:
-                armorType = ArmorType.Light;
-                break;
-           case UnitClass.Mage:
-                armorType = ArmorType.Medium;
-                break;
-            case UnitClass.Sage:
-                armorType = ArmorType.Light;
-                break;
-            case UnitClass.Cavalry:
-                armorType = ArmorType.Medium;
-                break;
-            case UnitClass.Paladin:
-                armorType = ArmorType.Heavy;
-                break;
-        }
+        // switch (unitClass){
+        //     case UnitClass.Infantry:
+        //         armorType = ArmorType.Medium;
+        //         break;
+        //     case UnitClass.Knight:
+        //         armorType = ArmorType.Heavy;
+        //         break;
+        //     case UnitClass.Assassin:
+        //         armorType = ArmorType.Light;
+        //         break;
+        //    case UnitClass.Mage:
+        //         armorType = ArmorType.Medium;
+        //         break;
+        //     case UnitClass.Sage:
+        //         armorType = ArmorType.Light;
+        //         break;
+        //     case UnitClass.Cavalry:
+        //         armorType = ArmorType.Medium;
+        //         break;
+        //     case UnitClass.Paladin:
+        //         armorType = ArmorType.Heavy;
+        //         break;
+        // }
     }
 
     public virtual int MaxTileRange(){
@@ -657,6 +657,32 @@ public class BaseUnit : MonoBehaviour
 
     public int GetDroppedXP(){
         return droppedXP;
+    }
+
+    public bool CanUseSkill(BaseItem item){
+        if (item is not BaseSkill){
+            return false;
+        }
+        return CanUseSkill(item as BaseSkill);
+    }
+    public bool CanUseSkill(BaseSkill newSkill){
+        if (newSkill.weaponClass != this.weaponClass && newSkill.weaponClass != WeaponClass.None){
+            return false;
+        }
+        if (newSkill.unitClass != this.unitClass && newSkill.unitClass != UnitClass.None){
+            return false;
+        }
+        return true;
+    }
+
+    public bool CanUseWeapon(BaseItem item){
+        if (item is not BaseWeapon){
+            return false;
+        }
+        return CanUseWeapon(item as BaseWeapon);
+    }
+    public bool CanUseSkill(BaseWeapon newWeapon){
+        return newWeapon.weaponClass == this.weaponClass;
     }
 }
 

--- a/Assets/Scripts/Units/BaseUnit.cs
+++ b/Assets/Scripts/Units/BaseUnit.cs
@@ -666,7 +666,7 @@ public class BaseUnit : MonoBehaviour
         return CanUseSkill(item as BaseSkill);
     }
     public bool CanUseSkill(BaseSkill newSkill){
-        if (newSkill == null){
+        if (newSkill == null || skills.Contains(newSkill)){
             return false;
         }
         if (newSkill.weaponClass != this.weaponClass && newSkill.weaponClass != WeaponClass.None){

--- a/Assets/Scripts/Units/BaseUnit.cs
+++ b/Assets/Scripts/Units/BaseUnit.cs
@@ -669,10 +669,10 @@ public class BaseUnit : MonoBehaviour
         if (newSkill == null || skills.Contains(newSkill)){
             return false;
         }
-        if (newSkill.weaponClass != this.weaponClass && newSkill.weaponClass != WeaponClass.None){
+        if (newSkill.weaponClass != this.weaponClass && newSkill.weaponClass != WeaponClass.Any){
             return false;
         }
-        if (newSkill.unitClass != this.unitClass && newSkill.unitClass != UnitClass.None){
+        if (newSkill.unitClass != this.unitClass && newSkill.unitClass != UnitClass.Any){
             return false;
         }
         return true;
@@ -704,7 +704,7 @@ public enum UnitStatType {
 }
 
 public enum UnitClass {
-    None,
+    Any,
     Infantry,
     Knight,
     Assassin,

--- a/Assets/Scripts/Units/BaseUnit.cs
+++ b/Assets/Scripts/Units/BaseUnit.cs
@@ -660,12 +660,15 @@ public class BaseUnit : MonoBehaviour
     }
 
     public bool CanUseSkill(BaseItem item){
-        if (item is not BaseSkill){
+        if (item == null || item is not BaseSkill){
             return false;
         }
         return CanUseSkill(item as BaseSkill);
     }
     public bool CanUseSkill(BaseSkill newSkill){
+        if (newSkill == null){
+            return false;
+        }
         if (newSkill.weaponClass != this.weaponClass && newSkill.weaponClass != WeaponClass.None){
             return false;
         }
@@ -676,12 +679,15 @@ public class BaseUnit : MonoBehaviour
     }
 
     public bool CanUseWeapon(BaseItem item){
-        if (item is not BaseWeapon){
+        if (item == null || item is not BaseWeapon){
             return false;
         }
         return CanUseWeapon(item as BaseWeapon);
     }
-    public bool CanUseSkill(BaseWeapon newWeapon){
+    public bool CanUseWeapon(BaseWeapon newWeapon){
+        if (newWeapon == null){
+            return false;
+        }        
         return newWeapon.weaponClass == this.weaponClass;
     }
 }

--- a/Assets/Scripts/Units/MeleeUnit.cs
+++ b/Assets/Scripts/Units/MeleeUnit.cs
@@ -54,4 +54,12 @@ public class MeleeUnit : BaseUnit
         }
         return returns;
     }
+
+    protected override void InitializeUnitClass(){
+        if (this.meleeWeaponClass == WeaponMeleeClass.LongArms){
+            this.weaponClass = WeaponClass.LongArms;
+        }else{
+            this.weaponClass = WeaponClass.SideArms;
+        }
+    }
 }

--- a/Assets/Scripts/Units/RangedUnit.cs
+++ b/Assets/Scripts/Units/RangedUnit.cs
@@ -101,4 +101,13 @@ public class RangedUnit : BaseUnit
         next.ForEach(t => GVAHelper(depth + 1, max, t, visited, startTile, startUnit));
         return;
     }
+
+    
+    protected override void InitializeUnitClass(){
+        if (this.rangedWeaponClass == WeaponRangedClasss.Archer){
+            this.weaponClass = WeaponClass.Archer;
+        }else{
+            this.weaponClass = WeaponClass.Magic;
+        }
+    }
 }

--- a/Assets/Scripts/Weapons/BaseWeapon.cs
+++ b/Assets/Scripts/Weapons/BaseWeapon.cs
@@ -13,7 +13,7 @@ public enum WeaponAttackMethod {
     Ranged,
 }
 public enum WeaponClass {
-    None,
+    Any,
     LongArms,
     SideArms,
     Archer,
@@ -27,15 +27,4 @@ public enum WeaponMeleeClass {
 public enum WeaponRangedClasss {
     Archer,
     Magic,
-}
-
-public enum WeaponSubclass{
-    Sword,
-    Mace,
-    Handaxe,
-    Spear,
-    Polaxe,
-    Warpick,
-    Bow,
-    Crossbow,
 }


### PR DESCRIPTION
Inventory menu now lets you swap items between units and the player's inventory

Open the inventory with Y on an xbox controller or TAB on a keyboard
Swap between units and inventory with LB/RB on a controller or [/] on keyboard

To edit what items are in the inventory at start, look for the `items` list in the InventoryManager on the hierarchy

-When selecting an item held by a unit, it brings up the inventory and disables items that cannot replace it, sorting the enabled items to the front of the menu
-Selecting an item in the inventory will swap both items, equipping the second selected item

-When hovering an item in the inventory, it highlights the units that would be able to use it
-When selecting an item from the inventory, it brings up unit management and disables slots for units that cannot equip the item
-Selecting an slot for a unit after this will swap both items, equipping the first selected item

https://github.com/AlexMarrinan/RavenGuard/assets/57539939/45470cc9-80b2-4a9f-a7d2-fbfc9cce20b0

